### PR TITLE
Fix link to repository

### DIFF
--- a/src/eiconv.app.src
+++ b/src/eiconv.app.src
@@ -7,5 +7,5 @@
     {env, []},
     {maintainers, ["Zotonic Team"]},
     {licenses, ["Apache 2.0"]},
-    {links, [{"GitHub", "https://github.com/zotonic/z_stdlib"}]}
+    {links, [{"GitHub", "https://github.com/zotonic/eiconv"}]}
 ]}.


### PR DESCRIPTION
The link to the GitHub repo on hex.pm points to `zotonic/z_stdlib` instead of `zotonic/eiconv`.