### PR TITLE
Fix Dialyzer warnings

### DIFF
--- a/src/eiconv.erl
+++ b/src/eiconv.erl
@@ -42,17 +42,17 @@ init() ->
 % @doc Open a new encoder which can be used to convert text from FromCode into ToCode.
 %
 open(_ToCode, _FromCode) ->
-    exit(nif_library_not_loaded).
+    erlang:nif_error(nif_library_not_loaded).
 
 % @doc Convert a chunk, returns {done, ConvertedBytes} } | {more, Converted}
 %
 chunk(_Cd, _Input) ->
-    exit(nif_library_not_loaded).
+    erlang:nif_error(nif_library_not_loaded).
 
 % @doc Reset the cd structure, returns ok | {rest, LeftOverBytes}
 %
 finalize(_Cd) ->
-    exit(nif_library_not_loaded).
+    erlang:nif_error(nif_library_not_loaded).
 
 % @doc Convert Input into the requested encoding.
 %


### PR DESCRIPTION
Replacing `exit` exceptions in NIF stubs with `erlang:nif_error` calls is enough for Dialyzer to stop considering those functions as unrepentant failures.

This is especially useful for library consumers, since the misinformed Dialyzer type model would propagate all the way into them and sabotage proper static analysis.